### PR TITLE
Fixed consumer commit issue.

### DIFF
--- a/it-test/src/test/java/io/datanerds/verteiler/it_test/BlockingQueueConsumerTest.java
+++ b/it-test/src/test/java/io/datanerds/verteiler/it_test/BlockingQueueConsumerTest.java
@@ -22,6 +22,7 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
     private static final Logger logger = LoggerFactory.getLogger(BlockingQueueConsumerTest.class);
     private static final LoremIpsum LOREM_IPSUM = new LoremIpsum();
     private static final int NUMBER_OF_MESSAGES = 100000;
+    private static final String TEST_GROUP = "TestGroup";
 
     @BeforeClass
     public static void setUp() {
@@ -41,7 +42,7 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
         Consumer<String> action = (message) -> messageCounter.incrementAndGet();
 
         ConsumerConfig<String, String> config =
-                new ConsumerConfig<>(kafkaConnect, "TestGroup", "my_topic", new StringDeserializer(),
+                new ConsumerConfig<>(kafkaConnect, TEST_GROUP, "my_topic", new StringDeserializer(),
                         new StringDeserializer());
         BlockingQueueConsumer<String, String> consumer = new BlockingQueueConsumer<>(config, 42, action);
         consumer.start();
@@ -65,7 +66,7 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
         Consumer<String> action = (message) -> messageCounter.incrementAndGet();
 
         ConsumerConfig<String, String> config =
-                new ConsumerConfig<>(kafkaConnect, "TestGroup", "my_reassignment_topic", new StringDeserializer(),
+                new ConsumerConfig<>(kafkaConnect, TEST_GROUP, "my_reassignment_topic", new StringDeserializer(),
                         new StringDeserializer());
         BlockingQueueConsumer<String, String> consumer = new BlockingQueueConsumer<>(config, 42, action);
         consumer.start();
@@ -77,7 +78,7 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
             testProducer.send(LOREM_IPSUM.paragraph());
             if (i == NUMBER_OF_MESSAGES / 10) {
                 anotherConsumer = new BlockingQueueConsumer<>(
-                        new ConsumerConfig<>(kafkaConnect, "TestGroup", "my_reassignment_topic",
+                        new ConsumerConfig<>(kafkaConnect, TEST_GROUP, "my_reassignment_topic",
                                 new StringDeserializer(), new StringDeserializer()), 42, action);
                 anotherConsumer.start();
             }
@@ -89,5 +90,36 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
         await().atMost(5, SECONDS).until(() -> messageCounter.get() >= NUMBER_OF_MESSAGES);
         testProducer.close();
         anotherConsumer.stop();
+    }
+
+    @Test
+    public void testSendOneMessageRestartConsumerEnsureOneMessageOnly() throws Exception {
+        final String topic = "low_load_topic";
+
+        createTopic(topic);
+
+        AtomicInteger messageCounter = new AtomicInteger();
+        Consumer<String> action = (message) -> messageCounter.incrementAndGet();
+
+        ConsumerConfig<String, String> config =
+                new ConsumerConfig<>(kafkaConnect, TEST_GROUP, topic, new StringDeserializer(),
+                        new StringDeserializer());
+
+        BlockingQueueConsumer<String, String> consumer0 = new BlockingQueueConsumer<>(config, 5, action);
+        consumer0.start();
+
+        SimpleTestProducer testProducer = new SimpleTestProducer("Lorem-Radio", topic, kafkaConnect);
+        logger.info("Sending 1 message");
+
+        testProducer.send(LOREM_IPSUM.paragraph());
+
+        await().atMost(5, SECONDS).until(() -> messageCounter.get() == 1);
+        consumer0.stop();
+
+        BlockingQueueConsumer<String, String> consumer1 = new BlockingQueueConsumer<>(config, 5, action);
+        consumer1.start();
+
+        await().atMost(2, SECONDS).until(() -> messageCounter.get() == 1);
+        consumer1.stop();
     }
 }

--- a/it-test/src/test/java/io/datanerds/verteiler/it_test/BlockingQueueConsumerTest.java
+++ b/it-test/src/test/java/io/datanerds/verteiler/it_test/BlockingQueueConsumerTest.java
@@ -95,6 +95,7 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
     @Test
     public void testSendOneMessageRestartConsumerEnsureOneMessageOnly() throws Exception {
         final String topic = "low_load_topic";
+        final String group = "OneMessageGroup";
 
         createTopic(topic);
 
@@ -102,7 +103,7 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
         Consumer<String> action = (message) -> messageCounter.incrementAndGet();
 
         ConsumerConfig<String, String> config =
-                new ConsumerConfig<>(kafkaConnect, TEST_GROUP, topic, new StringDeserializer(),
+                new ConsumerConfig<>(kafkaConnect, group, topic, new StringDeserializer(),
                         new StringDeserializer());
 
         BlockingQueueConsumer<String, String> consumer0 = new BlockingQueueConsumer<>(config, 5, action);

--- a/verteiler/src/main/java/io/datanerds/verteiler/ConsumerRecordRelay.java
+++ b/verteiler/src/main/java/io/datanerds/verteiler/ConsumerRecordRelay.java
@@ -50,7 +50,7 @@ class ConsumerRecordRelay<K, V> implements Runnable {
     }
 
     public void setOffset(ConsumerRecord<K, V> record) {
-        offsets.put(new TopicPartition(record.topic(), record.partition()), new OffsetAndMetadata(record.offset()));
+        offsets.put(new TopicPartition(record.topic(), record.partition()), new OffsetAndMetadata(record.offset() + 1));
         updateOffsets = true;
     }
 
@@ -60,6 +60,7 @@ class ConsumerRecordRelay<K, V> implements Runnable {
 
     private void commitOffsets() {
         if (updateOffsets) {
+            logger.trace("Commiting offsets {}", offsets);
             consumer.commitAsync(offsets, this::callback);
             updateOffsets = false;
         }

--- a/verteiler/src/main/java/io/datanerds/verteiler/ConsumerRecordRelay.java
+++ b/verteiler/src/main/java/io/datanerds/verteiler/ConsumerRecordRelay.java
@@ -60,7 +60,6 @@ class ConsumerRecordRelay<K, V> implements Runnable {
 
     private void commitOffsets() {
         if (updateOffsets) {
-            logger.trace("Commiting offsets {}", offsets);
             consumer.commitAsync(offsets, this::callback);
             updateOffsets = false;
         }


### PR DESCRIPTION
   The consumer was committing the offset of the message when it should have been committing the offset + 1 per the kafka documentation.  This was causing duplicate message when starting and stopping a consumer.