### PR TITLE
Made consumer config more flexible.

### DIFF
--- a/it-test/src/test/java/io/datanerds/verteiler/it_test/BlockingQueueConsumerTest.java
+++ b/it-test/src/test/java/io/datanerds/verteiler/it_test/BlockingQueueConsumerTest.java
@@ -6,16 +6,20 @@ import io.datanerds.verteiler.it_test.producer.SimpleTestProducer;
 import net._01001111.text.LoremIpsum;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.*;
 
 public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
 
@@ -23,6 +27,8 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
     private static final LoremIpsum LOREM_IPSUM = new LoremIpsum();
     private static final int NUMBER_OF_MESSAGES = 100000;
     private static final String TEST_GROUP = "TestGroup";
+
+    private Properties props;
 
     @BeforeClass
     public static void setUp() {
@@ -34,20 +40,27 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
         EmbeddedKafkaTest.tearDown();
     }
 
+    @Before
+    public void setUpTest() throws Exception {
+        props = new Properties();
+        props.setProperty(BOOTSTRAP_SERVERS_CONFIG, kafkaConnect);
+        props.setProperty(GROUP_ID_CONFIG, TEST_GROUP);
+    }
+
     @Test
     public void sendAndReceiveTest() throws Exception {
-        createTopic("my_topic");
+        final String topic = "my_topic";
+        createTopic(topic);
 
         AtomicInteger messageCounter = new AtomicInteger();
         Consumer<String> action = (message) -> messageCounter.incrementAndGet();
 
         ConsumerConfig<String, String> config =
-                new ConsumerConfig<>(kafkaConnect, TEST_GROUP, "my_topic", new StringDeserializer(),
-                        new StringDeserializer());
+                new ConsumerConfig<>(topic, props, new StringDeserializer(), new StringDeserializer());
         BlockingQueueConsumer<String, String> consumer = new BlockingQueueConsumer<>(config, 42, action);
         consumer.start();
 
-        SimpleTestProducer testProducer = new SimpleTestProducer("Lorem-Radio", "my_topic", kafkaConnect);
+        SimpleTestProducer testProducer = new SimpleTestProducer("Lorem-Radio", topic, kafkaConnect);
         logger.info("Sending {} messages", NUMBER_OF_MESSAGES);
 
         for (int i = 0; i < NUMBER_OF_MESSAGES; i++) {
@@ -61,25 +74,26 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
 
     @Test
     public void reassignmentTest() throws Exception {
-        createTopic("my_reassignment_topic");
+        final String topic = "my_reassignment_topic";
+        createTopic(topic);
+
         AtomicInteger messageCounter = new AtomicInteger();
         Consumer<String> action = (message) -> messageCounter.incrementAndGet();
 
         ConsumerConfig<String, String> config =
-                new ConsumerConfig<>(kafkaConnect, TEST_GROUP, "my_reassignment_topic", new StringDeserializer(),
-                        new StringDeserializer());
+                new ConsumerConfig<>(topic, props, new StringDeserializer(), new StringDeserializer());
         BlockingQueueConsumer<String, String> consumer = new BlockingQueueConsumer<>(config, 42, action);
         consumer.start();
 
-        SimpleTestProducer testProducer = new SimpleTestProducer("Lorem-Radio", "my_reassignment_topic", kafkaConnect);
+        SimpleTestProducer testProducer = new SimpleTestProducer("Lorem-Radio", topic, kafkaConnect);
         logger.info("Sending {} messages", NUMBER_OF_MESSAGES);
         BlockingQueueConsumer<String, String> anotherConsumer = null;
         for (int i = 0; i < NUMBER_OF_MESSAGES; i++) {
             testProducer.send(LOREM_IPSUM.paragraph());
             if (i == NUMBER_OF_MESSAGES / 10) {
                 anotherConsumer = new BlockingQueueConsumer<>(
-                        new ConsumerConfig<>(kafkaConnect, TEST_GROUP, "my_reassignment_topic",
-                                new StringDeserializer(), new StringDeserializer()), 42, action);
+                        new ConsumerConfig<>(
+                                topic, props, new StringDeserializer(), new StringDeserializer()), 42, action);
                 anotherConsumer.start();
             }
             if (i == NUMBER_OF_MESSAGES / 5) {
@@ -96,6 +110,7 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
     public void testSendOneMessageRestartConsumerEnsureOneMessageOnly() throws Exception {
         final String topic = "low_load_topic";
         final String group = "OneMessageGroup";
+        props.setProperty(GROUP_ID_CONFIG, group);
 
         createTopic(topic);
 
@@ -103,8 +118,7 @@ public class BlockingQueueConsumerTest extends EmbeddedKafkaTest {
         Consumer<String> action = (message) -> messageCounter.incrementAndGet();
 
         ConsumerConfig<String, String> config =
-                new ConsumerConfig<>(kafkaConnect, group, topic, new StringDeserializer(),
-                        new StringDeserializer());
+                new ConsumerConfig<>(topic, props,  new StringDeserializer(), new StringDeserializer());
 
         BlockingQueueConsumer<String, String> consumer0 = new BlockingQueueConsumer<>(config, 5, action);
         consumer0.start();

--- a/verteiler/src/main/java/io/datanerds/verteiler/BlockingQueueConfigValidator.java
+++ b/verteiler/src/main/java/io/datanerds/verteiler/BlockingQueueConfigValidator.java
@@ -1,0 +1,43 @@
+package io.datanerds.verteiler;
+
+import java.util.Properties;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.*;
+
+final class BlockingQueueConfigValidator implements KafkaConfigValidator {
+    private static volatile BlockingQueueConfigValidator validator;
+
+    static BlockingQueueConfigValidator getValidator() {
+        if (validator == null) {
+            synchronized (BlockingQueueConfigValidator.class) {
+                if (validator == null) {
+                    validator = new BlockingQueueConfigValidator();
+                }
+            }
+        }
+
+        return validator;
+    }
+
+    private BlockingQueueConfigValidator() {}
+
+    @Override
+    public void validate(Properties props) {
+        verifyPropsNotNull(props);
+        verifyAutoCommitDisabled(props);
+    }
+
+    private void verifyPropsNotNull(Properties props) {
+        if (props == null) {
+            throw new IllegalArgumentException("Kafka properties must not be null");
+        }
+    }
+
+    private void verifyAutoCommitDisabled(Properties props) {
+        Boolean isAutoCommitEnabled = Boolean.valueOf(props.getProperty(ENABLE_AUTO_COMMIT_CONFIG));
+        if (isAutoCommitEnabled) {
+            throw new IllegalArgumentException(
+                    ENABLE_AUTO_COMMIT_CONFIG + " must not be enabled for the BlockingQueueConsumer");
+        }
+    }
+}

--- a/verteiler/src/main/java/io/datanerds/verteiler/ConsumerConfig.java
+++ b/verteiler/src/main/java/io/datanerds/verteiler/ConsumerConfig.java
@@ -2,19 +2,21 @@ package io.datanerds.verteiler;
 
 import org.apache.kafka.common.serialization.Deserializer;
 
+import java.util.Properties;
+
 public class ConsumerConfig<K, V> {
 
-    public final String brokerBootstrap;
-    public final String groupId;
     public final String topic;
+    public final Properties consumerProperties;
     public final Deserializer<K> keyDeserializer;
     public final Deserializer<V> valueDeserializer;
 
-    public ConsumerConfig(String brokerBootstrap, String groupId, String topic,
-            Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
-        this.brokerBootstrap = brokerBootstrap;
-        this.groupId = groupId;
+    public ConsumerConfig(String topic,
+                          Properties consumerProperties,
+                          Deserializer<K> keyDeserializer,
+                          Deserializer<V> valueDeserializer) {
         this.topic = topic;
+        this.consumerProperties = consumerProperties;
         this.keyDeserializer = keyDeserializer;
         this.valueDeserializer = valueDeserializer;
     }

--- a/verteiler/src/main/java/io/datanerds/verteiler/KafkaConfigValidator.java
+++ b/verteiler/src/main/java/io/datanerds/verteiler/KafkaConfigValidator.java
@@ -1,0 +1,13 @@
+package io.datanerds.verteiler;
+
+import java.util.Properties;
+
+interface KafkaConfigValidator {
+    /**
+     * Validates whether the given Kafka configuration is suitable for Consumer configuration.  Depending on the
+     * Consumer type, some kafka fields should not be changed.
+     *
+     * @param props    Kafka client properties
+     */
+    void validate(Properties props);
+}

--- a/verteiler/src/test/java/io/datanerds/verteiler/BlockingQueueConfigValidatorTest.java
+++ b/verteiler/src/test/java/io/datanerds/verteiler/BlockingQueueConfigValidatorTest.java
@@ -1,0 +1,58 @@
+package io.datanerds.verteiler;
+
+import static org.junit.Assert.*;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Properties;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BlockingQueueConfigValidatorTest {
+    private BlockingQueueConfigValidator validator;
+    private Properties testProps;
+
+    @Before
+    public void setUp() throws Exception {
+        validator = BlockingQueueConfigValidator.getValidator();
+
+        testProps = new Properties();
+        testProps.setProperty(ENABLE_AUTO_COMMIT_CONFIG, "false");
+    }
+
+    @Test
+    public void testGetValidator() throws Exception {
+        final BlockingQueueConfigValidator other = BlockingQueueConfigValidator.getValidator();
+        assertThat(validator, is(equalTo(other)));
+    }
+
+    @Test
+    public void testValidate() throws Exception {
+        validator.validate(testProps);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateAutoCommitTrue() throws Exception {
+        testProps.setProperty(ENABLE_AUTO_COMMIT_CONFIG, "true");
+        validator.validate(testProps);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateNullProperties() throws Exception {
+        validator.validate(null);
+    }
+}


### PR DESCRIPTION
Consumer configuration will now be provided a properties field with the typical Kafka properties populated in it.  Our version of the consumer will validate that auto commit is not enabled.  But otherwise the client can configure the consumer with all other config fields.

@larsp 