### PR TITLE
Expose stopped from Processor for easier testing

### DIFF
--- a/verteiler/src/main/java/io/datanerds/verteiler/Processor.java
+++ b/verteiler/src/main/java/io/datanerds/verteiler/Processor.java
@@ -42,6 +42,7 @@ class Processor<K, V> implements Runnable {
         } catch (Exception ex) {
             logger.error("Exception during processing {}. Stopping!", topicPartition, ex);
         }
+        stopped = true;
         queue.clear();
         logger.info("Processor for {} stopped", topicPartition);
     }
@@ -52,5 +53,9 @@ class Processor<K, V> implements Runnable {
 
     public void queue(ConsumerRecord<K, V> record) throws InterruptedException {
         queue.put(record);
+    }
+
+    public boolean isStopped() {
+        return stopped;
     }
 }

--- a/verteiler/src/main/java/io/datanerds/verteiler/Processor.java
+++ b/verteiler/src/main/java/io/datanerds/verteiler/Processor.java
@@ -42,7 +42,7 @@ class Processor<K, V> implements Runnable {
         } catch (Exception ex) {
             logger.error("Exception during processing {}. Stopping!", topicPartition, ex);
         }
-        stopped = true;
+        stop();
         queue.clear();
         logger.info("Processor for {} stopped", topicPartition);
     }

--- a/verteiler/src/test/java/io/datanerds/verteiler/ProcessorTest.java
+++ b/verteiler/src/test/java/io/datanerds/verteiler/ProcessorTest.java
@@ -80,4 +80,16 @@ public class ProcessorTest {
         verify(relay, never()).setOffset(record);
     }
 
+    @Test
+    public void stoppedSetOnException() throws Exception {
+        final Processor<Integer, String> processor = new Processor<>(new TopicPartition("Hello", 1), relay, message -> {
+            throw new RuntimeException("Foobar! Something went wrong");
+        }, 42);
+
+        new Thread(processor).start();
+        processor.queue(record);
+
+        await().until(processor::isStopped, is(equalTo(true)));
+    }
+
 }


### PR DESCRIPTION
To better support testing we would export the property `Processor.isStopped()` so we can verify that the processor stops on the right conditions.